### PR TITLE
Don't tie the gem to Rails. 

### DIFF
--- a/lib/compass_twitter_bootstrap.rb
+++ b/lib/compass_twitter_bootstrap.rb
@@ -1,6 +1,6 @@
 require "compass_twitter_bootstrap/version"
 
-if ::Rails.version >= "3.1"
+if defined?(::Rails) && ::Rails.version >= "3.1"
   require 'compass_twitter_bootstrap/engine'
 end
 


### PR DESCRIPTION
Either that or make Rails a dependency on this gem. Using this with Padrino I get:

```
NameError on line 3 of .../gems/compass_twitter_bootstrap-0.1.8/lib/compass_twitter_bootstrap.rb: uninitialized constant Rails
```
