### PR TITLE
Catch a potential 'included the file twice' glitch

### DIFF
--- a/lib/compass_twitter_bootstrap/version.rb
+++ b/lib/compass_twitter_bootstrap/version.rb
@@ -1,3 +1,3 @@
 module CompassTwitterBootstrap
-  VERSION = "0.1.8"
+  CompassTwitterBootstrap::VERSION = "0.1.8" unless defined?(CompassTwitterBootstrap::VERSION)
 end


### PR DESCRIPTION
Using bundle exec compass watch this file can get called twice, resulting in an -already defined VERSION- error. This removes that possibility.
