### PR TITLE
Fixes the looping bug in bootstrap carousel

### DIFF
--- a/vendor/assets/javascripts/bootstrap-carousel.js
+++ b/vendor/assets/javascripts/bootstrap-carousel.js
@@ -83,8 +83,6 @@
         , fallback  = type == 'next' ? 'first' : 'last'
         , that = this
 
-      if (!$next.length) return
-
       this.sliding = true
 
       isCycling && this.pause()


### PR DESCRIPTION
This is going to be fixed in the 2.0.2 release but I don't want to wait for it. It is a one line fix.
