### PR TITLE
Fix for escape function e() carryover from the less source code.

### DIFF
--- a/stylesheets/compass_twitter_bootstrap/_buttons.scss
+++ b/stylesheets/compass_twitter_bootstrap/_buttons.scss
@@ -53,7 +53,7 @@
   $shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
   @include box-shadow($shadow);
   background-color: darken($white, 10%);
-  background-color: darken($white, 15%) e("\9");
+  background-color: darken($white, 15%)\9;
   outline: 0;
 }
 

--- a/stylesheets/compass_twitter_bootstrap/_mixins.scss
+++ b/stylesheets/compass_twitter_bootstrap/_mixins.scss
@@ -537,7 +537,7 @@
   // IE 7 + 8 can't handle box-shadow to show active, so we darken a bit ourselves
   &:active,
   &.active {
-    background-color: darken($endColor, 10%) e("\9");
+    background-color: darken($endColor, 10%)\9;
   }
 }
 

--- a/stylesheets_sass/compass_twitter_bootstrap/_buttons.sass
+++ b/stylesheets_sass/compass_twitter_bootstrap/_buttons.sass
@@ -49,7 +49,7 @@
   $shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.05)
   +box-shadow($shadow)
   background-color: darken($white, 10%)
-  background-color: darken($white, 15%) e("\9")
+  background-color: darken($white, 15%)\9
   outline: 0
 
 // Disabled state

--- a/stylesheets_sass/compass_twitter_bootstrap/_mixins.sass
+++ b/stylesheets_sass/compass_twitter_bootstrap/_mixins.sass
@@ -486,7 +486,7 @@
   // IE 7 + 8 can't handle box-shadow to show active, so we darken a bit ourselves
   &:active,
   &.active
-    background-color: darken($endColor, 10%) e("\9")
+    background-color: darken($endColor, 10%)\9
 
 // COMPONENT MIXINS
 // --------------------------------------------------

--- a/stylesheets_sass/compass_twitter_bootstrap/_modals.sass
+++ b/stylesheets_sass/compass_twitter_bootstrap/_modals.sass
@@ -48,7 +48,7 @@
   +box-shadow(0 3px 7px rgba(0, 0, 0, 0.3))
   +background-clip(padding-box)
   &.fade
-    +transition(e("opacity .3s linear, top .3s ease-out"))
+    +transition("opacity .3s linear, top .3s ease-out")
     top: -25%
   &.fade.in
     top: 50%


### PR DESCRIPTION
This just eliminates the e() function altogether.
