### PR TITLE
Added bootstrap-all.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ To use the font awesome font and icons simply change the standard import to:
 
     @import "compass_twitter_bootstrap_awesome"
 
+## Using Javascripts with Rails Asset Pipeline
+
+Javascript Libraries are located in vendor/assets/javascripts
+
+Include them individually or 
+
+    //=require bootstrap-all
+
+to include all files
+
+
 ## TWITTER BOOTSTRAP
 
 Bootstrap is Twitter's toolkit for kickstarting CSS for websites, apps, and more. It includes base CSS styles for typography, forms, buttons, tables, grids, navigation, alerts, and more.

--- a/vendor/assets/javascripts/bootstrap-all.js
+++ b/vendor/assets/javascripts/bootstrap-all.js
@@ -1,0 +1,12 @@
+//=require bootstrap-transition
+//=require bootstrap-alert
+//=require bootstrap-modal
+//=require bootstrap-dropdown
+//=require bootstrap-scrollspy
+//=require bootstrap-tab
+//=require bootstrap-tooltip
+//=require bootstrap-popover
+//=require bootstrap-button
+//=require bootstrap-collapse
+//=require bootstrap-carousel
+//=require bootstrap-typeahead


### PR DESCRIPTION
- bootstrap-all.js in vendor/assets/javascripts which includes files in the correct order as shown by the examples in the twitter-bootstrap docs.
