### PR TITLE
Use rgba instead of transparent

### DIFF
--- a/stylesheets_sass/compass_twitter_bootstrap/_mixins.sass
+++ b/stylesheets_sass/compass_twitter_bootstrap/_mixins.sass
@@ -370,7 +370,7 @@
   background-image: -moz-linear-gradient($angle, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent)
   background-image: -ms-linear-gradient($angle, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent)
   background-image: -o-linear-gradient($angle, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent)
-  background-image: linear-gradient($angle, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent)
+  background-image: linear-gradient($angle, rgba(255, 255, 255, 0.15) 25%, rgba(255,255,255,0) 25%, rgba(255,255,255,0) 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, rgba(255,255,255,0) 75%, rgba(255,255,255,0))
 
 // Reset filters for IE
 =bootstrap-reset-filter


### PR DESCRIPTION
This is to address "Expected color, got transparent" error which causes scss not to compile via the CLI. 

As documented elsewhere: https://github.com/yabawock/bootstrap-sass-rails/issues/1
