### PR TITLE
Fixes for broken sprites 

### DIFF
--- a/stylesheets/compass_twitter_bootstrap/_variables.scss
+++ b/stylesheets/compass_twitter_bootstrap/_variables.scss
@@ -128,8 +128,8 @@ $zindexModal:             1050 !default;
 
 // Sprite icons path
 // -------------------------
-$iconSpritePath:          "../img/glyphicons-halflings.png" !default;
-$iconWhiteSpritePath:     "../img/glyphicons-halflings-white.png" !default;
+$iconSpritePath:          "glyphicons-halflings.png" !default;
+$iconWhiteSpritePath:     "glyphicons-halflings-white.png" !default;
 
 
 // Input placeholder text color

--- a/stylesheets_sass/compass_twitter_bootstrap/_sprites.sass
+++ b/stylesheets_sass/compass_twitter_bootstrap/_sprites.sass
@@ -21,12 +21,12 @@
   +bootstrap-ie7-restore-right-whitespace
   line-height: 14px
   vertical-align: text-top
-  background-image: url(#{$iconSpritePath})
+  background-image: image-url(#{$iconSpritePath})
   background-position: 14px 14px
   background-repeat: no-repeat
 
 .icon-white
-  background-image: url(#{$iconWhiteSpritePath})
+  background-image: image-url(#{$iconWhiteSpritePath})
 
 .icon-glass
   background-position: 0      0

--- a/stylesheets_sass/compass_twitter_bootstrap/_variables.sass
+++ b/stylesheets_sass/compass_twitter_bootstrap/_variables.sass
@@ -128,8 +128,8 @@ $zindexModal: 1050 !default
 
 // Sprite icons path
 // -------------------------
-$iconSpritePath: "../img/glyphicons-halflings.png" !default
-$iconWhiteSpritePath: "../img/glyphicons-halflings-white.png" !default
+$iconSpritePath: "glyphicons-halflings.png" !default
+$iconWhiteSpritePath: "glyphicons-halflings-white.png" !default
 
 // Input placeholder text color
 // -------------------------


### PR DESCRIPTION
Commit with upgrade to bootstrap 2.0.3 broke asset pipeline support in sprites.
