### PR TITLE
Make sure only files are being fetched, not directories in convert script

### DIFF
--- a/build/convert.rb
+++ b/build/convert.rb
@@ -73,6 +73,7 @@ private
     file = replace_spin(file)
     file = replace_opacity(file)
     file = replace_image_urls(file)
+    file = replace_image_paths(file)
 
     file
   end
@@ -136,7 +137,11 @@ private
   end
 
   def replace_image_urls(less)
-    less.gsub(/background-image: url\((.*)\);/) {|s| "background-image: image-url(\"#{$1.gsub('../img/','')}\");" }
+    less.gsub(/background-image: url\("?(.*?)"?\);/) {|s| "background-image: image-url(\"#{$1}\");" }
+  end
+
+  def replace_image_paths(less)
+    less.gsub('../img/', '')
   end
 
   def insert_default_vars(scss)

--- a/build/convert.rb
+++ b/build/convert.rb
@@ -74,6 +74,7 @@ private
     file = replace_opacity(file)
     file = replace_image_urls(file)
     file = replace_image_paths(file)
+    file = replace_escaping(file)
 
     file
   end
@@ -142,6 +143,11 @@ private
 
   def replace_image_paths(less)
     less.gsub('../img/', '')
+  end
+
+  def replace_escaping(less)
+    less = less.gsub(/\~"([^"]+)"/, '#{\1}') # Get rid of ~ escape
+    less.gsub(/(\W)e\("([^\)]+)"\)/) {|s| "#{$1 if $1 != /\s/}#{$2}"} # Get rid of e escape
   end
 
   def insert_default_vars(scss)

--- a/build/convert.rb
+++ b/build/convert.rb
@@ -57,7 +57,7 @@ private
   def get_less_files
     files = open("https://api.github.com/repos/twitter/bootstrap/git/trees/#{get_tree_sha}").read
     files = JSON.parse files
-    files['tree'].map{|f| f['path']}
+    files['tree'].select{|f| f['type'] == 'blob' }.map{|f| f['path'] }
   end
 
 

--- a/build/convert.rb
+++ b/build/convert.rb
@@ -62,6 +62,7 @@ private
 
 
   def convert(file)
+    file = replace_interpolation(file)
     file = replace_vars(file)
     file = replace_fonts(file)
     file = replace_font_family(file)
@@ -86,6 +87,10 @@ private
     f.write(content)
     f.close
     puts "Converted #{name}\n"
+  end
+
+  def replace_interpolation(less)
+    less.gsub(/@{([^}]+)}/, '#{$\1}')
   end
 
   def replace_vars(less)


### PR DESCRIPTION
Since a recent release of Bootstrap they include a tests folder in their
sass folder. The script just fetched this and failed on a Github 404.
Now, we only fetch blobs, not tree's
