### PR TITLE
Update to ctb-opacity mixin to correctly calculate opacity

### DIFF
--- a/stylesheets/compass_twitter_bootstrap/_mixins.scss
+++ b/stylesheets/compass_twitter_bootstrap/_mixins.scss
@@ -366,8 +366,8 @@
 
 // Opacity
 @mixin ctb-opacity($opacity) {
-  opacity: $opacity;
-  filter: alpha(opacity=($opacity * 100));
+  opacity: $opacity / 100;
+  filter: alpha(opacity=($opacity));
 }
 
 

--- a/stylesheets_sass/compass_twitter_bootstrap/_mixins.sass
+++ b/stylesheets_sass/compass_twitter_bootstrap/_mixins.sass
@@ -325,8 +325,8 @@
 
 // Opacity
 =ctb-opacity($opacity)
-  opacity: $opacity
-  filter: alpha(opacity = $opacity * 100)
+  opacity: $opacity / 100
+  filter: alpha(opacity = $opacity)
 
 // BACKGROUNDS
 // --------------------------------------------------


### PR DESCRIPTION
Currently everything using the ctb-opacity mixin is rendering the incorrect CSS value for opacity (and the MS equivalent).

This patch fixes this.
