### PR TITLE
fix bootstrap version comment

### DIFF
--- a/stylesheets/_compass_twitter_bootstrap.scss
+++ b/stylesheets/_compass_twitter_bootstrap.scss
@@ -1,5 +1,5 @@
 /*!
- * Bootstrap v2.1.0
+ * Bootstrap v2.2.2
  *
  * Copyright 2012 Twitter, Inc
  * Licensed under the Apache License v2.0

--- a/stylesheets/_compass_twitter_bootstrap_awesome.scss
+++ b/stylesheets/_compass_twitter_bootstrap_awesome.scss
@@ -1,5 +1,5 @@
 /*
- * Bootstrap v2.1.0
+ * Bootstrap v2.2.2
  *
  * Copyright 2012 Twitter, Inc
  * Licensed under the Apache License v2.0

--- a/stylesheets_sass/_compass_twitter_bootstrap.sass
+++ b/stylesheets_sass/_compass_twitter_bootstrap.sass
@@ -1,5 +1,5 @@
 /*!
- * Bootstrap v2.1.0
+ * Bootstrap v2.2.2
  *
  * Copyright 2012 Twitter, Inc
  * Licensed under the Apache License v2.0

--- a/stylesheets_sass/_compass_twitter_bootstrap_awesome.sass
+++ b/stylesheets_sass/_compass_twitter_bootstrap_awesome.sass
@@ -1,5 +1,5 @@
 /*
- * Bootstrap v2.1.0
+ * Bootstrap v2.2.2
  *
  * Copyright 2012 Twitter, Inc
  * Licensed under the Apache License v2.0


### PR DESCRIPTION
@vwall @tijsverkoyen It looks like vwall/compass-twitter-bootstrap#102 did not update the files

```
stylesheets/_compass_twitter_bootstrap.scss
stylesheets/_compass_twitter_bootstrap_awesome.scss
stylesheets_sass/_compass_twitter_bootstrap.sass
stylesheets_sass/_compass_twitter_bootstrap_awesome.sass
```

so "\* Bootstrap v2.1.0" is still getting compiled into our css. This is confusing if the Bootstrap version is actually 2.2.2. This patch just updates those version comments to 2.2.2. assuming that's what it should have been. Ideally the version comments in these files would be updated automatically along with the Bootstrap version so they wouldn't keep getting out of sync.
