### PR TITLE
Bringing back !default for some variables

### DIFF
--- a/stylesheets/compass_twitter_bootstrap/_variables.scss
+++ b/stylesheets/compass_twitter_bootstrap/_variables.scss
@@ -53,9 +53,9 @@ $baseFontFamily:        $sansFontFamily !default;
 $baseLineHeight:        20px !default;
 $altFontFamily:         $serifFontFamily !default;
 
-$headingsFontFamily:    inherit; // empty to use BS default, $baseFontFamily
-$headingsFontWeight:    bold;    // instead of browser default, bold
-$headingsColor:         inherit; // empty to use BS default, $textColor
+$headingsFontFamily:    inherit !default; // empty to use BS default, $baseFontFamily
+$headingsFontWeight:    bold !default;    // instead of browser default, bold
+$headingsColor:         inherit !default; // empty to use BS default, $textColor
 
 
 // Component sizing

--- a/stylesheets_sass/compass_twitter_bootstrap/_variables.sass
+++ b/stylesheets_sass/compass_twitter_bootstrap/_variables.sass
@@ -47,13 +47,13 @@ $baseFontFamily: $sansFontFamily !default
 $baseLineHeight: 20px !default
 $altFontFamily: $serifFontFamily !default
 
-$headingsFontFamily: inherit
+$headingsFontFamily: inherit  !default
 
 // empty to use BS default, $baseFontFamily
-$headingsFontWeight: bold
+$headingsFontWeight: bold  !default
 
 // instead of browser default, bold
-$headingsColor: inherit
+$headingsColor: inherit !default
 
 // empty to use BS default, $textColor
 


### PR DESCRIPTION
Using !default for $headingsColor, $headingsFontFamily and $headingsFontWeight

Please consider using !default for these variables (as in earlier versions), as it offers more flexibility for the users of the gem.
