### PR TITLE
bootstrap-affix no method error correction

### DIFF
--- a/vendor/assets/javascripts/bootstrap-all.js
+++ b/vendor/assets/javascripts/bootstrap-all.js
@@ -1,6 +1,6 @@
 //=require bootstrap-transition
 //=require bootstrap-alert
-//-require bootstrap-affix
+//=require bootstrap-affix
 //=require bootstrap-modal
 //=require bootstrap-dropdown
 //=require bootstrap-scrollspy


### PR DESCRIPTION
Not sure if using //- was intentional or a typo, but it cleared up the no method error I was getting when I attempt to implement bootstrap-affix
