### PR TITLE
Added missing !default for table colors

### DIFF
--- a/stylesheets/compass_twitter_bootstrap/_variables.scss
+++ b/stylesheets/compass_twitter_bootstrap/_variables.scss
@@ -77,10 +77,10 @@ $borderRadiusSmall:     3px !default;
 
 // Tables
 // -------------------------
-$tableBackground:                   transparent; // overall background-color
-$tableBackgroundAccent:             #f9f9f9; // for striping
-$tableBackgroundHover:              #f5f5f5; // for hover
-$tableBorder:                       #ddd; // table and cell border
+$tableBackground:                   transparent !default; // overall background-color
+$tableBackgroundAccent:             #f9f9f9 !default; // for striping
+$tableBackgroundHover:              #f5f5f5 !default; // for hover
+$tableBorder:                       #ddd !default; // table and cell border
 
 // Buttons
 // -------------------------

--- a/stylesheets_sass/compass_twitter_bootstrap/_variables.sass
+++ b/stylesheets_sass/compass_twitter_bootstrap/_variables.sass
@@ -87,16 +87,16 @@ $borderRadiusSmall: 3px !default
 
 // Tables
 // -------------------------
-$tableBackground: transparent
+$tableBackground: transparent !default
 
 // overall background-color
-$tableBackgroundAccent: #f9f9f9
+$tableBackgroundAccent: #f9f9f9 !default
 
 // for striping
-$tableBackgroundHover: whitesmoke
+$tableBackgroundHover: whitesmoke !default
 
 // for hover
-$tableBorder: #dddddd
+$tableBorder: #dddddd !default
 
 // table and cell border
 


### PR DESCRIPTION
The variables describing the table colors (background, accent, hover) were missing the `!default` flag, preventing the user to override them with his own values.
